### PR TITLE
Two fixes for xdot parser

### DIFF
--- a/src/part/DotGraphParsingHelper.cpp
+++ b/src/part/DotGraphParsingHelper.cpp
@@ -182,8 +182,8 @@ void DotGraphParsingHelper::setattributedlist()
   {
     if (attributes.find("bb") != attributes.end())
     {
-      std::vector< int > v;
-      parse_integers(attributes["bb"].c_str(), v);
+      std::vector< double > v;
+      parse_reals(attributes["bb"].c_str(), v);
       if (v.size()>=4)
       {
 //         qCDebug(KGRAPHVIEWERLIB_LOG) << "setting width and height to " << v[2] << v[3];

--- a/src/part/dotgrammar.cpp
+++ b/src/part/dotgrammar.cpp
@@ -223,8 +223,11 @@ void pushAttrList(char const* /*first*/, char const* /*last*/)
   if (phelper)
   {
     phelper->graphAttributesStack.push_back(phelper->graphAttributes);
+    phelper->graphAttributes.clear();
     phelper->nodesAttributesStack.push_back(phelper->nodesAttributes);
+    phelper->nodesAttributes.clear();
     phelper->edgesAttributesStack.push_back(phelper->edgesAttributes);
+    phelper->edgesAttributes.clear();
   }
 }
 
@@ -410,6 +413,16 @@ bool parse_integers(char const* str, std::vector<int>& v)
                (
                  int_p[push_back_a(v)] >> *(',' >> int_p[push_back_a(v)])
                )
+               ,
+               +space_p).full;
+}
+
+bool parse_reals(char const* str, std::vector<double>& v)
+{
+  return parse(str,
+               (
+		real_p[push_back_a(v)] >> *(',' >> real_p[push_back_a(v)])
+		)
                ,
                +space_p).full;
 }

--- a/src/part/dotgrammar.h
+++ b/src/part/dotgrammar.h
@@ -72,6 +72,7 @@ void finalactions(char const* first, char const* last);
 bool parse_point(char const* str, QPoint& p);
 bool parse_real(char const* str, double& d);
 bool parse_integers(char const* str, std::vector<int>& v);
+bool parse_reals(char const* str, std::vector<double>& v);
 bool parse_spline(char const* str, QVector< QPair< float, float > >& points);
 void init_op();
 void valid_op(char const* first, char const* last);


### PR DESCRIPTION
    - "bb" bounding box uses reals, not integers 
    - fix for empty subgraphs, do not in inherit subgraph attributes from a parent graph:

    digraph unnamed {
            graph [_draw_="c 9 -#fffffe00 C 7 -#ffffff P 4 0 0 0 231 1396.3 231 1396.3 0 ",
                    bb="0,0,1396.3,231",
                    compound=true,
                    fontsize=11,
                    id=unnamed,
                    xdotversion=1.7
            ];
            node [label="\N"];
            subgraph cluster_1 {
                    graph [_draw_="c 7 -#000000 p 4 8 152 8 204 202 204 202 152 ",
                            bb="8,152,202,204",
                            fontsize=10,
                            id=cluster_1
                    ];
                    cluster_1_MGMT_TARGET_PROPERTIES_1               [_draw_="c 7 -#000000 e 105 178 89.45 18 ",
                            _ldraw_="F 10 11 -Times-Roman c 7 -#000000 T 105 175.5 0 136 22 -MGMT_TARGET_PROPERTIES ",
                            comment="[27,50]",
                            fontsize=10,
                            height=0.5,
                            id=cluster_1_MGMT_TARGET_PROPERTIES_1,
                            label=MGMT_TARGET_PROPERTIES,
                            name=MGMT_TARGET_PROPERTIES,
                            pos="105,178",
                            width=2.4855];
            }
            subgraph cluster_4 {
                    graph [fontsize=10,
                            id=cluster_4
                    ];
            }
    }